### PR TITLE
Bug fix: whitespace is no longer stripped from user selected text

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Macaroni is a Chrome extension to help you quickly copy text you select as one o
   - [HTML entity encoding](https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references)
   - [JSON escaping](https://en.wikipedia.org/wiki/Escape_character#JavaScript)
 
+This extension was created for security testing, so the encoded data it produces should not be used in a trusted context.
+
 ## Installing extension from repo
 1. Download this repo as a ZIP file from GitHub.
 2. Unzip the file
@@ -21,6 +23,7 @@ Macaroni is a Chrome extension to help you quickly copy text you select as one o
 If you are curious or concerned about [the permissions requested by this extension](https://github.com/0xedward/macaroni/blob/main/src/manifest.json#L9-L11), the following is a brief explainer for each permission and where you can find it used in code:
 
 - `contextMenus` is used [to create a menu items for you to specify which encoding you want copied to your clipboard for the text you have selected](https://github.com/0xedward/macaroni/blob/main/src/background.js#L4-L26)
+- `tabs` is used to get the text you selected to pass to the encoder or decoder. `tabs`, and permissions to `http://*/` and `https://*/` are a workarounds for a [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=116429) with `chrome.contextMenus` API causing line breaks and new lines to not appear in `selectionText`
 
 ## Credits
 The extension [icon](https://thenounproject.com/search/?q=macaroni&i=1723765) was found on The Noun Project and was created by mikicon

--- a/src/background.js
+++ b/src/background.js
@@ -25,26 +25,34 @@ chrome.runtime.onInstalled.addListener( function() {
     'contexts': ['selection'],
   });
 
+
   chrome.contextMenus.onClicked.addListener(function(info) {
     if (typeof info != 'undefined') {
-      let resultString = '';
-      switch (info.menuItemId) {
-        case 'base64Encode':
-          resultString = base64Encode(info.selectionText);
-          break;
-        case 'urlEncode':
-          resultString = urlEncode(info.selectionText);
-          break;
-        case 'jsonEscape':
-          resultString = jsonEscape(info.selectionText);
-          break;
-        case 'htmlEntityEncode':
-          resultString = htmlEntityEncode(info.selectionText);
-          break;
-      }
-      if (resultString !== '') {
-        copyTextToClipboard(resultString);
-      }
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=116429
+      chrome.tabs.executeScript( {
+        code: 'window.getSelection().toString();',
+      }, function(selection) {
+        const selectionText = selection[0];
+        let resultString = '';
+        switch (info.menuItemId) {
+          case 'base64Encode':
+            resultString = base64Encode(selectionText);
+            break;
+          case 'urlEncode':
+            resultString = urlEncode(selectionText);
+            break;
+          case 'jsonEscape':
+            resultString = jsonEscape(selectionText);
+            break;
+          case 'htmlEntityEncode':
+            resultString = htmlEntityEncode(selectionText);
+            break;
+        }
+        if (resultString !== '') {
+          console.log(resultString);
+          copyTextToClipboard(resultString);
+        }
+      });
     }
   });
 },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,7 +8,10 @@
     "persistent": false
   },
   "permissions": [
-    "contextMenus"
+    "contextMenus",
+    "tabs",
+    "http://*/",
+    "https://*/"
   ],
   "icons": {
     "16": "assets/icon.png",


### PR DESCRIPTION
The solution is not ideal as it is a workaround to a [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=116429). The bug results in the extension requiring tabs permission to all http and https protocols.